### PR TITLE
refactor: 인플루언서 프로필 이미지 컬럼 길이 수정

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/Influencer.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/Influencer.java
@@ -24,13 +24,13 @@ public class Influencer {
     private String uuid;
     @Column(name = "name", nullable = false, length = 40)
     private String name;
-    @Column(name = "profile_image", nullable = false, length = 500)
+    @Column(name = "profile_image", nullable = false, length = 1000)
     private String profileImage;
     @Column(name = "phone_num", nullable = false, length = 20)
     private String phoneNum;
     @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
-    @Column(name = "description")
+    @Column(name = "description", length = 1000)
     private String description;
 
     @Builder

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/Influencer.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/Influencer.java
@@ -16,32 +16,32 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Influencer {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "influencer_id")
-	private Long id;
-	@Column(name = "influencer_uuid", nullable = false)
-	private String uuid;
-	@Column(name = "name", nullable = false, length = 40)
-	private String name;
-	@Column(name = "profile_image", nullable = false)
-	private String profileImage;
-	@Column(name = "phone_num", nullable = false, length = 20)
-	private String phoneNum;
-	@Column(name = "birth_date", nullable = false)
-	private LocalDate birthDate;
-	@Column(name = "description")
-	private String description;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "influencer_id")
+    private Long id;
+    @Column(name = "influencer_uuid", nullable = false)
+    private String uuid;
+    @Column(name = "name", nullable = false, length = 40)
+    private String name;
+    @Column(name = "profile_image", nullable = false, length = 500)
+    private String profileImage;
+    @Column(name = "phone_num", nullable = false, length = 20)
+    private String phoneNum;
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+    @Column(name = "description")
+    private String description;
 
-	@Builder
-	public Influencer(Long id, String uuid, String name, String profileImage, String phoneNum,
-		LocalDate birthDate, String description) {
-		this.id = id;
-		this.uuid = uuid;
-		this.name = name;
-		this.profileImage = profileImage;
-		this.phoneNum = phoneNum;
-		this.birthDate = birthDate;
-		this.description = description;
-	}
+    @Builder
+    public Influencer(Long id, String uuid, String name, String profileImage, String phoneNum,
+        LocalDate birthDate, String description) {
+        this.id = id;
+        this.uuid = uuid;
+        this.name = name;
+        this.profileImage = profileImage;
+        this.phoneNum = phoneNum;
+        this.birthDate = birthDate;
+        this.description = description;
+    }
 }


### PR DESCRIPTION
- [x] #166 
- 프로필 이미지 주소 길이가 255자를 넘는 경우가 있어 1000으로 수정했습니다.
- 설명 컬럼도 1000자로 수정했습니다.